### PR TITLE
Replace unique ID generation with property ID in scrapers

### DIFF
--- a/scrapers/olxScraper.js
+++ b/scrapers/olxScraper.js
@@ -3,7 +3,7 @@ const path = require("path");
 const { saveJSON } = require("../utils/fileHelper");
 const { convertDate } = require("../utils/dateHelper");
 const config = require("../config/olxConfig");
-const { generateUniqueId } = require("../utils/idGenerator");
+const { generatePropertyId } = require("../utils/idGenerator");
 
 // const { simulateInteractions } = require("../utils/interactionsHelper");
 const attributeMapping = {
@@ -56,7 +56,7 @@ const getHouseList = async (page) => {
       )?.innerText;
 
       const house = {
-        id: generateUniqueId(),
+        id: generatePropertyId(),
         address,
         description,
         images:

--- a/scrapers/zapScraper.js
+++ b/scrapers/zapScraper.js
@@ -2,7 +2,7 @@ const puppeteer = require("puppeteer");
 const fs = require("fs").promises;
 const path = require("path");
 const { saveJSON, loadJSON } = require("../utils/fileHelper");
-const { generateUniqueId } = require("../utils/idGenerator");
+const { generatePropertyId } = require("../utils/idGenerator");
 const { createTargetURL } = require("../config/zapConfig");
 const { simulateInteractions } = require("../utils/interactionsHelper");
 
@@ -49,7 +49,7 @@ const getHouseList = async (page) => {
       const simpleLink = li.querySelector("a")?.href;
 
       const house = {
-        id: generateUniqueId(),
+        id: generatePropertyId(),
         address,
         description,
         images,


### PR DESCRIPTION
Update the ID generation method in the OLX and Zap scrapers to use a dedicated function for generating property IDs, ensuring consistency in property identification.