### PR TITLE
Replace property ID generation function in OLX and Zap scrapers

### DIFF
--- a/scrapers/olxScraper.js
+++ b/scrapers/olxScraper.js
@@ -3,7 +3,6 @@ const path = require("path");
 const { saveJSON } = require("../utils/fileHelper");
 const { convertDate } = require("../utils/dateHelper");
 const config = require("../config/olxConfig");
-const { generatePropertyId } = require("../utils/idGenerator");
 
 // const { simulateInteractions } = require("../utils/interactionsHelper");
 const attributeMapping = {
@@ -54,7 +53,13 @@ const getHouseList = async (page) => {
       const publishDate = li.querySelector(
         'p[data-testid="ds-adcard-date"]'
       )?.innerText;
+      function generatePropertyId() {
+        const now = new Date();
+        const timestamp = now.getTime();
+        const randomSuffix = Math.floor(Math.random() * 1000);
 
+        return `prop_${timestamp}_${randomSuffix}`;
+      }
       const house = {
         id: generatePropertyId(),
         address,

--- a/scrapers/zapScraper.js
+++ b/scrapers/zapScraper.js
@@ -2,7 +2,6 @@ const puppeteer = require("puppeteer");
 const fs = require("fs").promises;
 const path = require("path");
 const { saveJSON, loadJSON } = require("../utils/fileHelper");
-const { generatePropertyId } = require("../utils/idGenerator");
 const { createTargetURL } = require("../config/zapConfig");
 const { simulateInteractions } = require("../utils/interactionsHelper");
 
@@ -47,7 +46,13 @@ const getHouseList = async (page) => {
       li.id = liId;
 
       const simpleLink = li.querySelector("a")?.href;
+      function generatePropertyId() {
+        const now = new Date();
+        const timestamp = now.getTime();
+        const randomSuffix = Math.floor(Math.random() * 1000);
 
+        return `prop_${timestamp}_${randomSuffix}`;
+      }
       const house = {
         id: generatePropertyId(),
         address,


### PR DESCRIPTION
Update the property ID generation logic directly within the OLX and Zap scrapers to ensure consistency and eliminate reliance on an external utility function.